### PR TITLE
Update Tokio to 1.x, hyper to 0.14

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,5 +45,6 @@ Cargo.lock
 .halt.releez.yml
 .idea
 routerify-websocket.iml
+.vscode/
 
 # End of https://www.gitignore.io/api/rust,macos

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,18 +25,18 @@ json = ["serde", "serde_json"]
 [dependencies]
 log = "0.4"
 derive_more = "0.99"
-routerify = "1.1"
-hyper = "0.13"
+routerify = "2.1"
+hyper = "0.14"
 headers = "0.3"
-tokio-tungstenite = { version = "0.10", default-features = false }
-futures = { version = "0.3", default-features = false }
-tokio = { version = "0.2", features = ["rt-core"] }
+tokio-tungstenite = { version="0.14", default-features=false }
+futures = { version="0.3", default-features=false }
+tokio = { version="1", features=["rt"] }
 
-serde = { version = "1.0", optional = true }
-serde_json = { version = "1.0", optional = true }
+serde = { version="1.0", optional=true }
+serde_json = { version="1.0", optional=true }
 
 [dev-dependencies]
-tokio = { version = "0.2", features = ["full"] }
-stream-body = "0.1"
-serde = { version = "1.0", features = ["derive"] }
-tokio-tungstenite = { version = "0.10", features = ["tls"] }
+tokio = { version = "1", features = ["full"] }
+stream-body = { git = "https://github.com/ErwanDL/stream-body" }
+serde = { version="1.0", features=["derive"] }
+tokio-tungstenite = { version="0.14", features=[] }

--- a/examples/simple_example.rs
+++ b/examples/simple_example.rs
@@ -5,6 +5,7 @@ use routerify::{Router, RouterService};
 // Import websocket types.
 use routerify_websocket::{upgrade_ws, Message, WebSocket};
 use std::{convert::Infallible, net::SocketAddr};
+use tokio;
 
 // A handler for websocket connections.
 async fn ws_handler(ws: WebSocket) {

--- a/examples/test.rs
+++ b/examples/test.rs
@@ -1,14 +1,11 @@
-use futures::{Sink, SinkExt, StreamExt};
+use futures::{SinkExt, StreamExt};
 use hyper::{Body, Request, Response, Server};
 use routerify::prelude::*;
 use routerify::{Middleware, Router, RouterService};
-use routerify_websocket::{upgrade_ws, upgrade_ws_with_config, Message, WebSocket, WebSocketConfig};
+use routerify_websocket::{upgrade_ws, WebSocket};
 use serde::{Deserialize, Serialize};
 use std::{convert::Infallible, net::SocketAddr};
-use tokio_tungstenite::{
-    tungstenite::protocol::{frame::coding::CloseCode, CloseFrame, Message as ClientMessage},
-    WebSocketStream,
-};
+use tokio_tungstenite::tungstenite::protocol::Message as ClientMessage;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct User {
@@ -19,7 +16,7 @@ struct User {
 async fn ws_handler(ws: WebSocket) {
     println!("new websocket connection: {}", ws.remote_addr());
 
-    let (mut tx, mut rx) = ws.split();
+    let (mut _tx, mut rx) = ws.split();
 
     while let Some(msg) = rx.next().await {
         let msg = msg.unwrap();
@@ -60,7 +57,7 @@ async fn main() {
     let server = Server::bind(&addr).serve(service);
 
     tokio::spawn(async move {
-        tokio::time::delay_for(tokio::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
 
         let (mut ws, resp) = tokio_tungstenite::connect_async("ws://127.0.0.1:3001/ws")
             .await
@@ -73,7 +70,7 @@ async fn main() {
 
         ws.close(None).await.unwrap();
 
-        tokio::time::delay_for(tokio::time::Duration::from_secs(3)).await;
+        tokio::time::sleep(tokio::time::Duration::from_secs(3)).await;
     });
 
     println!("App is running on: {}", addr);

--- a/examples/test_stream_body.rs
+++ b/examples/test_stream_body.rs
@@ -1,15 +1,15 @@
-use futures::{Sink, SinkExt, StreamExt};
-use hyper::{Request, Response, Server};
+use futures::StreamExt;
+use hyper::{Response, Server};
 use routerify::{Router, RouterService};
 use routerify_websocket::{upgrade_ws, WebSocket};
 use std::{convert::Infallible, net::SocketAddr};
 use stream_body::StreamBody;
-use tokio::prelude::*;
+use tokio;
 
 async fn ws_handler(ws: WebSocket) {
     println!("new websocket connection: {}", ws.remote_addr());
 
-    let (mut tx, mut rx) = ws.split();
+    let (_tx, mut rx) = ws.split();
 
     while let Some(msg) = rx.next().await {
         let msg = msg.unwrap();


### PR DESCRIPTION
This is the PR associated with #3. The main issue left is that stream-body needs to be updated as well (I am doing some work on this in https://github.com/ErwanDL/stream-body/tree/update-dependencies, but first we will need https://github.com/routerify/async-pipe-rs/pull/8 to be merged and deployed), or we should remove the stream-body example, which will not compile as is. Which solution is best according to you ?